### PR TITLE
Avoiding error loading chunk

### DIFF
--- a/gltflib/gltf.py
+++ b/gltflib/gltf.py
@@ -387,10 +387,14 @@ class GLTF:
                                f'got {len(b)} bytes.')
         chunk_length, = struct.unpack_from('<I', b, 0)
         chunk_type, = struct.unpack_from('<I', b, 4)
-        if chunk_type == GLB_JSON_CHUNK_TYPE:
-            self._load_glb_json_chunk_body(f, chunk_length)
-        else:
-            self._load_glb_binary_chunk_body(f, chunk_type, chunk_length)
+        try:
+            if chunk_type == GLB_JSON_CHUNK_TYPE:
+                self._load_glb_json_chunk_body(f, chunk_length)
+            else:
+                self._load_glb_binary_chunk_body(f, chunk_type, chunk_length)
+        except:
+            warnings.warn(f'GLB file length specified in file header ({bytelen}) does not match number of bytes '
+                          f'read ({pos}). The GLB file may be corrupt.', RuntimeWarning)
         return True
 
     def _load_glb_json_chunk_body(self, f: BinaryIO, bytelen: int) -> None:


### PR DESCRIPTION
As consequence that running a warning instead of a runtime error, it can happen in some GLBs that as the bytelen does not match with number of bytes f'read, it occurs an ERROR in the command 'b=f.read(bytelen)' in "_load_glb_json_chunk_body" and "_load_glb_binary_chunk_body".
I have tried this little modification in some GLBs with this problem, and it has solved the problem great.