### PR TITLE
Restrict dataclasses requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIRES_PYTHON = '>=3.6.0'
 
 # Required packages
 REQUIRED = [
-    'dataclasses>=0.6',
+    'dataclasses>=0.6; python_version < "3.7"',
     'dataclasses-json>=0.2.2'
 ]
 


### PR DESCRIPTION
Dataclasses is only a requirement for python < 3.7.  Allowing it to be listed for later versions can result in issues when this package is consumed in some scenarios (in my case, executable packaging).